### PR TITLE
D4D_Menu

### DIFF
--- a/D4D/graphic_objects/d4d_menu.c
+++ b/D4D/graphic_objects/d4d_menu.c
@@ -296,7 +296,7 @@ static void D4D_MenuOnDraw(D4D_MESSAGE* pMsg)
     D4D_DrawTextRect(&tmp_point, &tmp_size, &tmp_txtbuff, clrT, clrB);
   }
 
-  for(tmpB = 0; (tmpB < _calc.posCnt) && (tmpB < _calc.itemsCnt); tmpB++)
+  for(tmpB = 0; (tmpB < _calc.posCnt) && (tmpB + pMenu->pData->page_ix < _calc.itemsCnt); tmpB++)
   {
     if(((pMenu->pData->ix - pMenu->pData->page_ix) != tmpB) || (!D4D_IsEnabled(pThis)))
     {


### PR DESCRIPTION
In D4D_MenuOnDraw(): Index overflow when accessing Menu Items array,
I encounter the problem after calling D4D_MenuSetIndex().
the Data in  pMenu->pItems[tmpB + pMenu->pData->page_ix] may be invalid when tmpB + pMenu->pData->page_ix > the items count