### PR TITLE
Change paths style to Unix style to avoid compilation errors

### DIFF
--- a/D4D/low_level_drivers/touch_screen/touch_screen_drivers/resistive/d4dtch_resistive.c
+++ b/D4D/low_level_drivers/touch_screen/touch_screen_drivers/resistive/d4dtch_resistive.c
@@ -59,7 +59,7 @@
 
   // include of low level driver heaser file
   // it will be included into wole project only in case that this driver is selected in main D4D configuration file
-  #include "low_level_drivers\touch_screen\touch_screen_drivers\resistive\d4dtch_resistive.h"
+  #include "low_level_drivers/touch_screen/touch_screen_drivers/resistive/d4dtch_resistive.h"
   /******************************************************************************
   * Macros
   ******************************************************************************/

--- a/D4D/low_level_drivers/touch_screen/touch_screen_hw_interface/kinetis_adc_12b/d4dtchhw_kinetis_adc.c
+++ b/D4D/low_level_drivers/touch_screen/touch_screen_hw_interface/kinetis_adc_12b/d4dtchhw_kinetis_adc.c
@@ -53,7 +53,7 @@
 
 #if (D4D_MK_STR(D4D_LLD_TCH_HW) == d4dtchhw_kinetis_adc_ID)
 
-  #include "low_level_drivers\touch_screen\touch_screen_hw_interface\kinetis_adc_12b\d4dtchhw_kinetis_adc.h"
+  #include "low_level_drivers/touch_screen/touch_screen_hw_interface/kinetis_adc_12b/d4dtchhw_kinetis_adc.h"
   /******************************************************************************
   * Macros
   ******************************************************************************/


### PR DESCRIPTION
Minor change to fix error when using touch driver under Unix system. Also in concordance with rest of library code.